### PR TITLE
Mau 21.02 r1s

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -256,11 +256,11 @@ define U-Boot/nanopi_neo2
   UENV:=a64
 endef
 
-define U-Boot/nanopi_r1s
+define U-Boot/nanopi_r1s_h5
   BUILD_SUBTARGET:=cortexa53
   NAME:=U-Boot for NanoPi R1S (H5)
-  BUILD_DEVICES:=friendlyarm_nanopi-r1s
-  DEPENDS:=+PACKAGE_u-boot-nanopi_r1s:arm-trusted-firmware-sunxi
+  BUILD_DEVICES:=friendlyarm_nanopi-r1s-h5
+  DEPENDS:=+PACKAGE_u-boot-nanopi_r1s_h5:arm-trusted-firmware-sunxi
   UENV:=a64
 endef
 
@@ -340,7 +340,7 @@ UBOOT_TARGETS := \
 	nanopi_neo_plus2 \
 	nanopi_neo2 \
 	nanopi_r1 \
-    nanopi_r1s \
+    nanopi_r1s_h5 \
 	orangepi_zero \
 	orangepi_r1 \
 	orangepi_one \

--- a/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -1,20 +1,28 @@
 --- /dev/null
-+++ b/arch/arm/dts/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,120 @@
++++ b/arch/arm/dts/sun50i-h5-nanopi-r1s-h5.dts
+@@ -0,0 +1,265 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+// Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++/*
++ * Copyright (C) 2021 Chukun Pan <amadeus@jmu.edu.cn>
++ *
++ * Based on sun50i-h5-nanopi-neo-plus2.dts, which is:
++ *   Copyright (C) 2017 Antony Antony <antony@phenome.org>
++ *   Copyright (C) 2016 ARM Ltd.
++ */
 +
 +/dts-v1/;
 +#include "sun50i-h5.dtsi"
 +
 +#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
 +
 +/ {
-+	model = "FriendlyARM NanoPi R1S";
-+	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
++	model = "FriendlyARM NanoPi R1S H5";
++	compatible = "friendlyarm,nanopi-r1s-h5", "allwinner,sun50i-h5";
 +
 +	aliases {
 +		ethernet0 = &emac;
++		ethernet1 = &rtl8189etv;
 +		serial0 = &uart0;
 +	};
 +
@@ -25,15 +33,30 @@
 +	leds {
 +		compatible = "gpio-leds";
 +
-+		pwr {
-+			label = "nanopi:green:pwr";
-+			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
-+			default-state = "on";
++		led-0 {
++			label = "nanopi:green:lan";
++			gpios = <&pio 0 9 GPIO_ACTIVE_HIGH>;
 +		};
 +
-+		status {
-+			label = "nanopi:blue:status";
++		led-1 {
++			label = "nanopi:red:status";
 +			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-2 {
++			label = "nanopi:green:wan";
++			gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	r-gpio-keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
 +		};
 +	};
 +
@@ -63,6 +86,105 @@
 +		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
 +		status = "okay";
 +	};
++
++	vdd_cpux: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0x1>;
++		states = <1100000 0x0>, <1300000 0x1>;
++	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
++		post-power-on-delay-ms = <200>;
++	};
++
++	cpu_opp_table: cpu-opp-table {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		opp-408000000 {
++			opp-hz = /bits/ 64 <408000000>;
++			opp-microvolt = <1000000 1000000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-648000000 {
++			opp-hz = /bits/ 64 <648000000>;
++			opp-microvolt = <1040000 1040000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <1080000 1080000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-912000000 {
++			opp-hz = /bits/ 64 <912000000>;
++			opp-microvolt = <1120000 1120000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-960000000 {
++			opp-hz = /bits/ 64 <960000000>;
++			opp-microvolt = <1160000 1160000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <1200000 1200000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1056000000 {
++			opp-hz = /bits/ 64 <1056000000>;
++			opp-microvolt = <1240000 1240000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1104000000 {
++			opp-hz = /bits/ 64 <1104000000>;
++			opp-microvolt = <1260000 1260000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1152000000 {
++			opp-hz = /bits/ 64 <1152000000>;
++			opp-microvolt = <1300000 1300000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++	};
++};
++
++&cpu0 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu1 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu2 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu3 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_cpux>;
 +};
 +
 +&ehci1 {
@@ -78,7 +200,7 @@
 +	pinctrl-0 = <&emac_rgmii_pins>;
 +	phy-supply = <&reg_gmac_3v3>;
 +	phy-handle = <&ext_rgmii_phy>;
-+	phy-mode = "rgmii";
++	phy-mode = "rgmii-id";
 +	status = "okay";
 +};
 +
@@ -89,11 +211,34 @@
 +	};
 +};
 +
++&i2c0 {
++	status = "okay";
++
++	eeprom@51 {
++		compatible = "microchip,24c02";
++		reg = <0x51>;
++		pagesize = <16>;
++	};
++};
++
 +&mmc0 {
 +	vmmc-supply = <&reg_vcc3v3>;
 +	bus-width = <4>;
 +	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
 +	status = "okay";
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	rtl8189etv: sdio_wifi@1 {
++		reg = <1>;
++	};
 +};
 +
 +&ohci1 {
@@ -127,12 +272,12 @@
  	sun50i-h5-libretech-all-h5-cc.dtb \
  	sun50i-h5-nanopi-neo2.dtb \
  	sun50i-h5-nanopi-neo-plus2.dtb \
-+    sun50i-h5-nanopi-r1s.dtb \
++    sun50i-h5-nanopi-r1s-h5.dtb \
  	sun50i-h5-orangepi-zero-plus.dtb \
  	sun50i-h5-orangepi-pc2.dtb \
  	sun50i-h5-orangepi-prime.dtb \
 --- /dev/null
-+++ b/configs/nanopi_r1s_defconfig
++++ b/configs/nanopi_r1s_h5_defconfig
 @@ -0,0 +1,14 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
@@ -144,7 +289,7 @@
 +CONFIG_MACPWR="PD6"
 +CONFIG_MMC_SUNXI_SLOT_EXTRA=2
 +# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
-+CONFIG_DEFAULT_DEVICE_TREE="sun50i-h5-nanopi-r1s"
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-h5-nanopi-r1s-h5"
 +CONFIG_SUN8I_EMAC=y
 +CONFIG_USB_EHCI_HCD=y
 +CONFIG_USB_OHCI_HCD=y

--- a/target/linux/sunxi/base-files/etc/board.d/01_leds
+++ b/target/linux/sunxi/base-files/etc/board.d/01_leds
@@ -12,9 +12,9 @@ friendlyarm,nanopi-r1)
 	ucidef_set_led_netdev "wan" "WAN" "nanopi:green:wan" "eth0"
 	ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"
 	;;
-friendlyarm,nanopi-r1s)
-    ucidef_set_led_netdev "wan" "WAN" "nanopi:green:wan" "eth0"
-    ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"
+friendlyarm,nanopi-r1s-h5)
+    ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
+    ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth1"
     ;;
 esac
 

--- a/target/linux/sunxi/base-files/etc/board.d/02_network
+++ b/target/linux/sunxi/base-files/etc/board.d/02_network
@@ -11,6 +11,9 @@ case $(board_name) in
 friendlyarm,nanopi-r1)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"
 	;;
+friendlyarm,nanopi-r1s-h5)
+	ucidef_set_interfaces_lan_wan "eth1" "eth0"
+	;;
 lamobo,lamobo-r1)
 	ucidef_add_switch "switch0" \
 		"4:lan:1" "0:lan:2" "1:lan:3" "2:lan:4" "3:wan" "8@eth0"

--- a/target/linux/sunxi/image/cortexa53.mk
+++ b/target/linux/sunxi/image/cortexa53.mk
@@ -35,16 +35,14 @@ define Device/friendlyarm_nanopi-neo2
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo2
 
-define Device/friendlyarm_nanopi-r1s
+define Device/friendlyarm_nanopi-r1s-h5
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R1S-H5
-  SUPPORTED_DEVICES:=nanopi-r1s
-  DEVICE_PACKAGES := kmod-rtc-sunxi kmod-usb2 kmod-usb-net-rtl8152 \
-     kmod-brcmfmac kmod-leds-gpio kmod-ledtrig-heartbeat wpad-basic-wolfssl \
-     brcmfmac-firmware-43430-sdio
+  DEVICE_PACKAGES := kmod-rtc-sunxi kmod-usb-net-rtl8152 \
+     kmod-leds-gpio kmod-ledtrig-heartbeat
   $(Device/sun50i-h5)
 endef
-TARGET_DEVICES += friendlyarm_nanopi-r1s
+TARGET_DEVICES += friendlyarm_nanopi-r1s-h5
 
 define Device/libretech_all-h3-cc-h5
   DEVICE_VENDOR := Libre Computer

--- a/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -4,9 +4,9 @@
            - const: friendlyarm,nanopi-neo2
            - const: allwinner,sun50i-h5
  
-+      - description: FriendlyARM NanoPi R1S
++      - description: FriendlyARM NanoPi R1S H5
 +        items:
-+          - const: friendlyarm,nanopi-r1s
++          - const: friendlyarm,nanopi-r1s-h5
 +          - const: allwinner,sun50i-h5
 +
        - description: FriendlyARM NanoPi Neo Air
@@ -18,66 +18,36 @@
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-emlid-neutis-n5-devboard.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-cc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
-+dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s-h5.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-pc2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-prime.dtb
 --- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,192 @@
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-r1s-h5.dts
+@@ -0,0 +1,269 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
-+ * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++ * Copyright (C) 2021 Chukun Pan <amadeus@jmu.edu.cn>
 + *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This file is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This file is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
++ * Based on sun50i-h5-nanopi-neo-plus2.dts, which is:
++ *   Copyright (C) 2017 Antony Antony <antony@phenome.org>
++ *   Copyright (C) 2016 ARM Ltd.
 + */
 +
 +/dts-v1/;
 +#include "sun50i-h5.dtsi"
 +
 +#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
 +
 +/ {
-+	model = "FriendlyARM NanoPi R1S";
-+	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
++	model = "FriendlyARM NanoPi R1S H5";
++	compatible = "friendlyarm,nanopi-r1s-h5", "allwinner,sun50i-h5";
 +
 +	aliases {
 +		ethernet0 = &emac;
++		ethernet1 = &rtl8189etv;
 +		serial0 = &uart0;
 +	};
 +
@@ -88,15 +58,33 @@
 +	leds {
 +		compatible = "gpio-leds";
 +
-+		pwr {
-+			label = "nanopi:green:pwr";
-+			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
-+			default-state = "on";
++		led-0 {
++			function = LED_FUNCTION_LAN;
++			color = <LED_COLOR_ID_GREEN>;
++			gpios = <&pio 0 9 GPIO_ACTIVE_HIGH>;
 +		};
 +
-+		status {
-+			label = "nanopi:blue:status";
++		led-1 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_RED>;
 +			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-2 {
++			function = LED_FUNCTION_WAN;
++			color = <LED_COLOR_ID_GREEN>;
++			gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	r-gpio-keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
 +		};
 +	};
 +
@@ -127,11 +115,104 @@
 +		status = "okay";
 +	};
 +
++	vdd_cpux: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0x1>;
++		states = <1100000 0x0>, <1300000 0x1>;
++	};
++
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
-+		pinctrl-names = "default";
-+		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
++		post-power-on-delay-ms = <200>;
 +	};
++
++	cpu_opp_table: cpu-opp-table {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		opp-408000000 {
++			opp-hz = /bits/ 64 <408000000>;
++			opp-microvolt = <1000000 1000000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-648000000 {
++			opp-hz = /bits/ 64 <648000000>;
++			opp-microvolt = <1040000 1040000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <1080000 1080000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-912000000 {
++			opp-hz = /bits/ 64 <912000000>;
++			opp-microvolt = <1120000 1120000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-960000000 {
++			opp-hz = /bits/ 64 <960000000>;
++			opp-microvolt = <1160000 1160000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <1200000 1200000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1056000000 {
++			opp-hz = /bits/ 64 <1056000000>;
++			opp-microvolt = <1240000 1240000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1104000000 {
++			opp-hz = /bits/ 64 <1104000000>;
++			opp-microvolt = <1260000 1260000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1152000000 {
++			opp-hz = /bits/ 64 <1152000000>;
++			opp-microvolt = <1300000 1300000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++	};
++};
++
++&cpu0 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu1 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu2 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu3 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_cpux>;
 +};
 +
 +&ehci1 {
@@ -147,7 +228,7 @@
 +	pinctrl-0 = <&emac_rgmii_pins>;
 +	phy-supply = <&reg_gmac_3v3>;
 +	phy-handle = <&ext_rgmii_phy>;
-+	phy-mode = "rgmii";
++	phy-mode = "rgmii-id";
 +	status = "okay";
 +};
 +
@@ -155,6 +236,16 @@
 +	ext_rgmii_phy: ethernet-phy@7 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <7>;
++	};
++};
++
++&i2c0 {
++	status = "okay";
++
++	eeprom@51 {
++		compatible = "microchip,24c02";
++		reg = <0x51>;
++		pagesize = <16>;
 +	};
 +};
 +
@@ -173,23 +264,9 @@
 +	non-removable;
 +	status = "okay";
 +
-+	sdio_wifi: sdio_wifi@1 {
++	rtl8189etv: sdio_wifi@1 {
 +		reg = <1>;
-+		compatible = "brcm,bcm4329-fmac";
-+		interrupt-parent = <&pio>;
-+		interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>;
-+		interrupt-names = "host-wake";
 +	};
-+};
-+
-+&mmc2 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&mmc2_8bit_pins>;
-+	vmmc-supply = <&reg_vcc3v3>;
-+	vqmmc-supply = <&reg_vcc3v3>;
-+	bus-width = <8>;
-+	non-removable;
-+	status = "okay";
 +};
 +
 +&ohci1 {


### PR DESCRIPTION
sunxi: add support for FriendlyARM NanoPi R1S H5
Specification:

It has the following features:

- Allwinner H5, Quad-core Cortex-A53
- 512MB DDR3 RAM
- 10/100/1000M Ethernet x 2
- RTL8189ETV WiFi 802.11b/g/n
- USB 2.0 host port (A)
- MicroSD Slot
- Serial Debug Port
- 5V 2A DC power-supply

Installation:

- Write the image to SD Card with dd
- Boot NanoPi from the SD Card

Signed-off-by: Marius Durbaca<mariusd84@gmail.com>
